### PR TITLE
Resetting AudioManager mode when user leaves the call + Skylink SDK 2.2.3 update

### DIFF
--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -32,11 +32,11 @@ repositories {
 android {
     compileSdkVersion 29
     defaultConfig {
-        applicationId "sg.com.temasys.skylink.sampleapp_2_2_1"
+        applicationId "sg.com.temasys.skylink.sampleapp_2_2_2"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 6
-        versionName "2.2.1"
+        versionCode 7
+        versionName "2.2.2"
         multiDexEnabled true
     }
     // Run lint checks but don't abort build
@@ -60,7 +60,7 @@ android {
 
         implementation(group: 'sg.com.temasys.skylink.sdk',
                 name: 'skylink_sdk',
-                version: '2.2.1-RELEASE',
+                version: '2.2.2-RELEASE',
                 ext: 'aar') {
             transitive = true
         }

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -32,11 +32,11 @@ repositories {
 android {
     compileSdkVersion 29
     defaultConfig {
-        applicationId "sg.com.temasys.skylink.sampleapp_2_2_2"
+        applicationId "sg.com.temasys.skylink.sampleapp_2_2_3"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 7
-        versionName "2.2.2"
+        versionCode 8
+        versionName "2.2.3"
         multiDexEnabled true
     }
     // Run lint checks but don't abort build
@@ -60,7 +60,7 @@ android {
 
         implementation(group: 'sg.com.temasys.skylink.sdk',
                 name: 'skylink_sdk',
-                version: '2.2.2-RELEASE',
+                version: '2.2.3-RELEASE',
                 ext: 'aar') {
             transitive = true
         }

--- a/sampleapp/src/main/java/sg/com/temasys/skylink/sdk/sampleapp/audio/AudioPresenter.java
+++ b/sampleapp/src/main/java/sg/com/temasys/skylink/sdk/sampleapp/audio/AudioPresenter.java
@@ -136,6 +136,8 @@ public class AudioPresenter extends BasePresenter implements AudioContract.Prese
 
     @Override
     public void processExit() {
+        AudioRouter.resetAudioMode();
+
         //process disconnect from room
         audioCallService.disconnectFromRoom();
 

--- a/sampleapp/src/main/java/sg/com/temasys/skylink/sdk/sampleapp/multivideos/MultiVideosPresenter.java
+++ b/sampleapp/src/main/java/sg/com/temasys/skylink/sdk/sampleapp/multivideos/MultiVideosPresenter.java
@@ -146,6 +146,8 @@ public class MultiVideosPresenter extends BasePresenter implements MultiVideosCo
 
     @Override
     public void processExit() {
+        AudioRouter.resetAudioMode();
+
         //process disconnect from room
         multiVideoCallService.disconnectFromRoom();
 

--- a/sampleapp/src/main/java/sg/com/temasys/skylink/sdk/sampleapp/utils/AudioRouter.java
+++ b/sampleapp/src/main/java/sg/com/temasys/skylink/sdk/sampleapp/utils/AudioRouter.java
@@ -236,6 +236,10 @@ public class AudioRouter {
         changeAudioOutput(false);
     }
 
+    public static void resetAudioMode() {
+        audioManager.setMode(AudioManager.MODE_NORMAL);
+    }
+
     /**
      * Set the audio path according to whether earphone is connected. Use ear piece if earphone is
      * connected. Use speakerphone if no earphone is connected.

--- a/sampleapp/src/main/java/sg/com/temasys/skylink/sdk/sampleapp/video/VideoPresenter.java
+++ b/sampleapp/src/main/java/sg/com/temasys/skylink/sdk/sampleapp/video/VideoPresenter.java
@@ -135,6 +135,8 @@ public class VideoPresenter extends BasePresenter implements VideoContract.Prese
 
     @Override
     public void processExit() {
+        AudioRouter.resetAudioMode();
+
         //process disconnect from room if connecting
         //after disconnected from skylink SDK, UI will be updated latter on processRoomDisconnected
         if (videoService.isConnectingOrConnected()) {

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">SampleApp 2.2.1</string>
+    <string name="app_name">SampleApp 2.2.2</string>
     <string name="title_section1"> Audio </string>
     <string name="title_section2"> Video </string>
     <string name="title_section3"> Chat </string>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">SampleApp 2.2.2</string>
+    <string name="app_name">SampleApp 2.2.3</string>
     <string name="title_section1"> Audio </string>
     <string name="title_section2"> Video </string>
     <string name="title_section3"> Chat </string>


### PR DESCRIPTION
When a Skylink call starts AudioManager mode is set to MODE_IN_COMMUNICATION but it was not resetted when exiting the call. With this change I reset the audio mode from IN_COMMUNICATION to NORMAL when user exits the call.